### PR TITLE
Removed current branch check

### DIFF
--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -31,10 +31,6 @@ jobs:
         with:
           fetch-depth: '0'
 
-      - name: Check ref
-        run: |
-          if [ "$(git rev-parse --abbrev-ref HEAD)" != "${{ inputs.ref }}" ]; then exit 1; fi
-
       - name: Run SSH agent
         run: |
           eval "$(ssh-agent -s)"


### PR DESCRIPTION
Because only the inputs.ref branch is pushed to the public remote it's not required to check if it's also the checked-out branch