### PR TITLE
Add projectBaseDir param forwarding for Sonarcloud

### DIFF
--- a/.github/actions/sonarcloud/action.yml
+++ b/.github/actions/sonarcloud/action.yml
@@ -4,7 +4,7 @@ inputs:
   sonar-token:
     description: 'Sonar token'
     required: true
-  projectBaseDir:
+  project-base-dir:
     description: Set the sonar.projectBaseDir analysis property
     required: false
     default: .
@@ -18,12 +18,12 @@ runs:
       env:
         SONAR_TOKEN: ${{ inputs.sonar-token }}
       with:
-        projectBaseDir: ${{ inputs.projectBaseDir }}
+        projectBaseDir: ${{ inputs.project-base-dir }}
     - name: 'Run SonarCloud scanner'
       if: ${{!contains(github.ref, '/pull/')}}
       uses: SonarSource/sonarcloud-github-action@v2.2.0
       env:
         SONAR_TOKEN: ${{ inputs.sonar-token }}
       with:
-        projectBaseDir: ${{ inputs.projectBaseDir }}
+        projectBaseDir: ${{ inputs.project-base-dir }}
         args: -Dsonar.branch.name=${{ github.ref_name }}


### PR DESCRIPTION
As this is used in https://github.com/minvws/nl-rdo-dataprocessing-register-private/blob/025d6b10615c550b0a0346004b82d62ab2e3564a/.github/workflows/ci.yml#L114