### PR TITLE
Add shadow branch and filter on dependabot.yml

### DIFF
--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -13,7 +13,7 @@ on:
         type: string
         default: 'main'
       shadow_branch:
-        description: 'private shadow branch of public repository'
+        description: 'Private shadow branch of public repository'
         required: true
         type: string
         default: 'main-public'


### PR DESCRIPTION
Because we don't want to run dependabot.yml on public repositories because it's already configured on the source repositories I would like to check for dependabot.yml to be absent when it's not allowed to run.