### PR TITLE
Use GITHUB_OUTPUT in venv package workflow

### DIFF
--- a/.github/actions/python-venv-package/action.yml
+++ b/.github/actions/python-venv-package/action.yml
@@ -33,10 +33,10 @@ runs:
       run: |
         if [ -f "requirements.txt" ]; then
           echo "::notice::requirements.txt file exists"
-          echo "::set-output name=file_exists::true"
+          echo "file_exists=true" >> $GITHUB_OUTPUT
         else
           echo "::notice::requirements.txt file does not exist"
-          echo "::set-output name=file_exists::false"
+          echo "file_exists=false" >> $GITHUB_OUTPUT
         fi
 
     - name: Check if poetry.lock file exists
@@ -45,10 +45,10 @@ runs:
       run: |
         if [ -f "poetry.lock" ]; then
           echo "::notice::poetry.lock file exists"
-          echo "::set-output name=file_exists::true"
+          echo "file_exists=true" >> $GITHUB_OUTPUT
         else
           echo "::notice::poetry.lock file does not exist"
-          echo "::set-output name=file_exists::false"
+          echo "file_exists=false" >> $GITHUB_OUTPUT
         fi
 
     - name: Export requirements (when Poetry)


### PR DESCRIPTION
I used the old method to set output. With this PR the warning is fixed.

> Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
