### PR TITLE
Add checkout toggle in venv package workflow

### DIFF
--- a/.github/actions/python-venv-package/action.yml
+++ b/.github/actions/python-venv-package/action.yml
@@ -7,8 +7,8 @@ inputs:
   package_file_name:
     description: "Name of the package"
     required: true
-  checkout_code:
-    description: "Whether to checkout code (true or false)"
+  checkout_repository:
+    description: "Whether to checkout the repository (true or false)"
     required: false
     default: 'true'
 
@@ -24,7 +24,7 @@ runs:
       run: echo "PACKAGE_FILE_NAME=${{ inputs.package_file_name }}_venv_${{ env.RELEASE_VERSION }}_python${{ inputs.python_version }}" >> $GITHUB_ENV
 
     - name: Checkout code
-      if: ${{ inputs.checkout_code == 'true' }}
+      if: ${{ inputs.checkout_repository == 'true' }}
       uses: actions/checkout@v4
 
     - name: Setup python

--- a/actions.md
+++ b/actions.md
@@ -60,7 +60,7 @@ This pipeline is designed to export a venv package for the specified Python vers
 
 ### Usage
 
-Here is are basic examples on how you can integrate it in your project.
+Here are basic examples on how you can integrate it in your project.
 
 <details>
   <summary>Example workflow</summary>
@@ -120,7 +120,7 @@ jobs:
         with:
           python_version: <python_version>
           package_file_name: <package_file_name>
-          checkout_code: 'false'
+          checkout_repository: 'false'
 ```
 
 </details>
@@ -131,7 +131,7 @@ The action has inputs. The inputs are:
 
 - python_version: Semver version of the Python version you want to use. For example `3.11` or `3.9`.
 - package_file_name: File name for the venv package. For example `nl-example-package`.
-- checkout_code: Boolean value inside string to enable or disable checkout code
+- checkout_repository: Boolean value inside string to enable or disable checkout repository
  in the action. For example `'true'` or `'false'`. Default `'true'`.
 
 ### Result


### PR DESCRIPTION
Now it is possible to checkout the repository before running the action and run additional actions for example changing directories before the venv package action runs.

Superseeds https://github.com/minvws/nl-irealisatie-generic-pipelines/pull/25