### PR TITLE
feat: add caching for venv in venv package workflow

### DIFF
--- a/.github/actions/python-venv-package/action.yml
+++ b/.github/actions/python-venv-package/action.yml
@@ -36,6 +36,7 @@ runs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.python_version }}
+        cache: pip
 
     - name: Check if requirements file exists
       id: check_requirements_file


### PR DESCRIPTION
Adds caching for the venv based on the specific project requirements.txt. The requirements file is created when a poetry lock file is used.
Also adds caching for the global pip.

Clean .venv so that action can be run multiple times.

Seperated the cache restore and cache save actions for venv caching so that we manage the cache instead of GitHub post actions.