### PR TITLE
fix: check if vcs requirements not empty in venv package workflow

### DIFF
--- a/.github/actions/python-venv-package/action.yml
+++ b/.github/actions/python-venv-package/action.yml
@@ -126,7 +126,9 @@ runs:
       run: |
         grep 'git\+' requirements.txt > requirements-vcs.txt
         grep 'git\+' -v requirements.txt > requirements-hashed.txt
-        pip install --no-deps -r requirements-vcs.txt
+        if test -s requirements-vcs.txt; then
+          pip install --no-deps -r requirements-vcs.txt
+        fi
         pip install -r requirements-hashed.txt
         rm requirements-vcs.txt requirements-hashed.txt
 


### PR DESCRIPTION
Build failed with an empty vcs requirements file https://github.com/minvws/nl-irealisatie-zmodules-addressing-register/actions/runs/10682577929/attempts/1.
