### PR TITLE
ci: add source package action and build script

### DIFF
--- a/.github/actions/src-package/action.yml
+++ b/.github/actions/src-package/action.yml
@@ -1,0 +1,56 @@
+name: "Creates a source package for an application"
+description: "Creates a tarball of source files and upload it as an artifact."
+
+inputs:
+  package_file_name:
+    description: "Name of the package (without extension) for example: nl-example-package."
+    required: true
+  include_paths:
+    description: "A space-separated list of paths to include in the package relative to the working_directory."
+    required: false
+    default: "."
+  working_directory:
+    description: "The base directory containing the source code, only required if it does not need to be the root folder."
+    required: false
+    default: "."
+  version_json_path:
+    description: "The location where version.json needs to be stored. For example `public/version.json`."
+    required: false
+    default: "version.json"
+  checkout_repository:
+    description: "Whether to checkout the repository (true or false)."
+    required: false
+    default: 'true'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout code
+      if: inputs.checkout_repository == 'true'
+      uses: actions/checkout@v4
+
+    - name: Extract version from tag
+      shell: bash
+      run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+    - name: Set package file name
+      shell: bash
+      run: echo "PACKAGE_FILE_NAME=${{ inputs.package_file_name }}_${{ env.RELEASE_VERSION }}" >> $GITHUB_ENV
+
+    - name: Create package archive
+      shell: bash
+      run: |
+        ./.github/scripts/build-src-package.sh \
+          --base-dir "${{ inputs.working_directory }}" \
+          --includes "${{ inputs.include_paths }}" \
+          --version ${{ env.RELEASE_VERSION }} \
+          --version-json-path "${{ inputs.version_json_path }}" \
+          --git-ref ${{ github.sha }} \
+          --output "${{ env.PACKAGE_FILE_NAME }}.tar.gz"
+
+    - name: Upload package artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ env.PACKAGE_FILE_NAME }}
+        path: ${{ env.PACKAGE_FILE_NAME }}.tar.gz
+        if-no-files-found: error

--- a/.github/scripts/build-src-package.sh
+++ b/.github/scripts/build-src-package.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+set -euo pipefail
+
+# Default values
+GIT_REF=$(git rev-parse HEAD 2>/dev/null || echo "local")
+INCLUDES=()
+RELEASE_VERSION=""
+ORIGINAL_DIR=$(pwd)
+OUTPUT_FILE=""
+BASE_DIR=""
+VERSION_JSON_PATH="version.json"
+
+function show_help {
+  echo "Usage: $0 [options]"
+  echo ""
+  echo "Build a release package with source files for an application"
+  echo ""
+  echo "Options:"
+  echo "  --base-dir             The base source directory (REQUIRED)"
+  echo "  --includes             A space-separated list of paths to include in the package relative to the --base-dir (REQUIRED)"
+  echo "  --version              Release version (REQUIRED)"
+  echo "  --output               Output file name (REQUIRED)"
+  echo "  --git-ref              Git reference (default: current HEAD)"
+  echo "  --version-json-path    The location where version.json needs to be stored (default: version.json)"
+  echo "  --help                 Display this help message"
+  echo ""
+  echo "Example:"
+  echo "  $0 --base-dir \".\" --includes \"app\" --version v1.0.0 --output mypackage.tar.gz"
+}
+
+# Parse command-line arguments
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --base-dir)
+      BASE_DIR="$2"
+      shift 2
+      ;;
+    --includes)
+      INCLUDES="$2"
+      shift 2
+      ;;
+    --version)
+      RELEASE_VERSION="$2"
+      shift 2
+      ;;
+    --output)
+      OUTPUT_FILE="$2"
+      shift 2
+      ;;
+    --git-ref)
+      GIT_REF="$2"
+      shift 2
+      ;;
+    --version-json-path)
+      VERSION_JSON_PATH="$2"
+      shift 2
+      ;;
+    --help)
+      show_help
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1"
+      show_help
+      exit 1
+      ;;
+  esac
+done
+
+# Required argument checks
+[ -z "$BASE_DIR" ] && { echo "ERROR: Source dir is required. Use --base-dir to set it."; show_help; exit 1; }
+[ -z "$INCLUDES" ] && { echo "ERROR: Include paths are required. Use --includes to set it."; show_help; exit 1; }
+[ -z "$RELEASE_VERSION" ] && { echo "ERROR: Release version is required. Use --version to set it."; show_help; exit 1; }
+[ -z "$OUTPUT_FILE" ] && { echo "ERROR: Output file name is required. Use --output to set it."; show_help; exit 1; }
+
+WORK_DIR="/tmp/package-${OUTPUT_FILE}"
+
+echo "Creating release package with the following settings:"
+echo "  Version:           ${RELEASE_VERSION}"
+echo "  Git ref:           ${GIT_REF}"
+echo "  Output:            ${OUTPUT_FILE}"
+echo "  Included paths:    ${INCLUDES}"
+echo "  version.json path: ${VERSION_JSON_PATH}"
+
+# Create a clean working directory
+rm -rf "${WORK_DIR}"
+mkdir -p "${WORK_DIR}"
+
+# Copy source files from the specified source directory
+cp -r "${BASE_DIR}"/* "${WORK_DIR}/"
+
+# Ensure the directory for version.json exists
+VERSION_JSON_DIR=$(dirname "${WORK_DIR}/${VERSION_JSON_PATH}")
+mkdir -p "${VERSION_JSON_DIR}"
+
+# Create or update the version.json with version and git_ref
+VERSION_JSON_FULL_PATH="${WORK_DIR}/${VERSION_JSON_PATH}"
+echo '{
+    "version": "'${RELEASE_VERSION}'",
+    "git_ref": "'${GIT_REF}'"
+}' > "${VERSION_JSON_FULL_PATH}"
+
+echo "Creating archive ${OUTPUT_FILE}..."
+
+# Create an empty file to avoid tar errors
+touch "${ORIGINAL_DIR}/${OUTPUT_FILE}"
+
+# Always include version.json in the tar
+EXTRA_INCLUDES="${VERSION_JSON_PATH}"
+tar -zcvf "${ORIGINAL_DIR}/${OUTPUT_FILE}" -C "${WORK_DIR}" ${INCLUDES} ${EXTRA_INCLUDES}
+
+echo "You can inspect the contents with: tar -tvf ${ORIGINAL_DIR}/${OUTPUT_FILE}"

--- a/actions.md
+++ b/actions.md
@@ -4,6 +4,8 @@ Here you can find the available actions. Each section will provide a description
 
 Available actions:
 
+- Generic
+  - [Source package](#source-package)
 - Python
   - [Python - Poetry install](#python---poetry-install)
   - [Python - venv package](#python---venv-package)
@@ -144,6 +146,104 @@ The action has inputs. The inputs are:
 This action will create a `.tar.gz` file containing the `.venv` directory. The file will be available as an artifact.
 
 The name of the artifact will be `<package_file_name>_venv_<tag_version>_python<python_version>.tar.gz`. For example `nl-example-package_venv_v0.0.1_python3.9.tar.gz`.
+
+The uploaded artifact will have a limited lifetime depending on what is currently configured.
+
+## Source package
+
+This pipeline is designed to export a source package for an application.
+
+### Usage
+
+Here are basic examples on how you can integrate it in your project.
+
+<details>
+  <summary>Example workflow</summary>
+
+This workflow is executed automatically on push of tags.
+
+In the code below you need to change the `working_directory` and `package_file_name` and `include_paths` according to the requirements of the project.
+See the [configuration section](#configuration-1).
+
+```yml
+name: Build release package
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  src-package:
+    runs-on: ubuntu-latest
+    steps:
+      # Using the action
+      - name: Create source package
+        uses: minvws/nl-irealisatie-generic-pipelines/.github/actions/src-package@main
+        with:
+          working_directory: "."
+          include_paths: "app static tools app.conf.example HOSTING_CHANGELOG.md"
+          package_file_name: "nl-irealisatie-project-name"
+```
+
+</details>
+
+<details>
+  <summary>Example workflow self checkout</summary>
+
+This workflow is executed automatically on push of tags. The workflow will checkout the repo and the action won't.
+
+In the code below you need to replace the `<package_file_name>` and `<working_directory>`. See the [configuration section](#configuration-2).
+
+```yml
+name: Build release package
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  src-package:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        shell: bash
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+      # Using the action
+      - name: Build src package
+        uses: minvws/nl-irealisatie-generic-pipelines/.github/actions/src-package@main
+        with:
+          checkout_repository: "false"
+          include_paths: "app static tools app.conf.example HOSTING_CHANGELOG.md"
+          package_file_name: "nl-irealisatie-project-name"
+```
+
+</details>
+
+### Configuration
+
+The action has inputs. The inputs are:
+
+- include_paths: A space seperated list with files and directories to include in the package relative to the working_directory.
+- package_file_name: Name of the package (without extension), for example: `nl-example-package`.
+- working_directory: The base directory containing the source code, only required if it does not need to be the root folder.
+- version_json_path: The location where version.json needs to be stored. For example `public/version.json`. Default: `version.json`.
+- checkout_repository: Boolean value inside string to enable or disable checkout repository
+ in the action. For example `'true'` or `'false'`. Default `'true'`.
+
+### Result
+
+This action will create a `.tar.gz` file containing the source files specified by `include_paths` relative to the base working directory specified by `working_directory`.
+The source package also contains an automatically generated `version.json` in the root of the package.
+The default location of the source package can be changed by using `version_json_path` input parameter of the github action.
+
+The source package will be available as an artifact and will look like: `<package_file_name>_<tag_version>.tar.gz`. For example `nl-example-package_v0.0.1.tar.gz`.
+The uploaded artifact will have a limited lifetime depending on what is currently configured.
 
 ## PHP - Composer install
 


### PR DESCRIPTION
Introduce a new GitHub Action for creating a source package for an application. 
The action generates a tarball of specified source files and uploads it as an artifact. 
Additionally, a supporting shell script is included to handle the package creation process, including versioning and file inclusion.