### PR TITLE
Remove poetry env from poetry install action

### DIFF
--- a/.github/actions/poetry-install/action.yml
+++ b/.github/actions/poetry-install/action.yml
@@ -21,10 +21,6 @@ runs:
         python-version: "${{ inputs.python_version }}"
         cache: poetry
 
-    - name: Set Poetry environment
-      shell: bash
-      run: poetry env use ${{ inputs.python_version }}
-
     - name: Install dependencies
       shell: bash
       run: poetry install


### PR DESCRIPTION
`poetry env use` is not be needed as te python version set is setup in `actions/setup-python@v5` is used.

Successfully tested in https://github.com/minvws/nl-rdo-max-private/actions/runs/15016283452/job/42194864905?pr=1363.