### PR TITLE
Run pip install with no-deps and require-hashes in venv package workflow

### DIFF
--- a/.github/actions/python-venv-package/action.yml
+++ b/.github/actions/python-venv-package/action.yml
@@ -121,13 +121,31 @@ runs:
 
     - name: Split requirements
       if: steps.cache-venv.outputs.cache-hit != 'true' && inputs.split_git_requirements == 'true'
+      id: split-requirements
       shell: bash
       working-directory: ${{ inputs.working_directory }}
       run: |
         grep 'git\+' requirements.txt > requirements-vcs.txt || true
-        grep 'git\+' -v requirements.txt > requirements-hashed.txt || true
+        grep 'git\+' -v requirements.txt > requirements-packages.txt || true
+        if grep -q -- '--hash=' requirements-packages.; then
+          echo "✅ Found hashes in requirements-packages.txt"
+          echo "require-hashes=--require-hashes" >> "$GITHUB_OUTPUT"
+        else
+          echo "❌ No hashes found in requirements-packages.txt"
+          echo "require-hashes=" >> "$GITHUB_OUTPUT"
+        fi
+    
+    - name: Show requirments
+      if: steps.cache-venv.outputs.cache-hit != 'true' && inputs.split_git_requirements == 'true'
+      shell: bash
+      working-directory: ${{ inputs.working_directory }}
+      run: |
+        echo "=== requirements-vcs.txt ==="
+        cat requirements-vcs.txt
+        echo "=== requirements-packages.txt ==="
+        cat requirements-packages.txt
 
-    - name: Install requirements (when split)
+    - name: Install requirements
       if: steps.cache-venv.outputs.cache-hit != 'true' && inputs.split_git_requirements == 'true'
       shell: bash
       working-directory: ${{ inputs.working_directory }}
@@ -135,8 +153,8 @@ runs:
         if test -s requirements-vcs.txt; then
           pip install --no-deps -r requirements-vcs.txt
         fi
-        if test -s requirements-hashed.txt; then
-          pip install -r requirements-hashed.txt
+        if test -s requirements-packages.txt; then
+          pip install --no-deps -r requirements-packages.txt ${{ steps.split-requirements.outputs.require-hashes }}
         fi
 
     - name: Cleanup split requirements
@@ -144,7 +162,7 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working_directory }}
       run: |
-        rm requirements-vcs.txt requirements-hashed.txt
+        rm requirements-vcs.txt requirements-packages.txt
 
     - uses: actions/cache/save@v4
       if: steps.cache-venv.outputs.cache-hit != 'true'


### PR DESCRIPTION
Technically we do not need `--require-hashes` because `pip install` will check hashes by default and when hashes exists they are required for all dependencies.

https://github.com/python-poetry/poetry-plugin-export

Added `--no-deps` to pip install, related to:
> When installing an exported requirements.txt via pip, you should always pass --no-deps because Poetry has already resolved the dependencies so that all direct and transitive requirements are included and it is not necessary to resolve again via pip. pip may even fail to resolve dependencies, especially if git dependencies, which are exported with their resolved hashes, are included.