### PR TITLE
chore: add deprecation warnings

### DIFF
--- a/.github/actions/composer-install/action.yml
+++ b/.github/actions/composer-install/action.yml
@@ -12,6 +12,11 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Log deprecation warning
+      shell: bash
+      run: |
+        echo "::warning title=Action deprecated::Please switch to the standlone version of this action: https://github.com/minvws/action-php-composer-install"
+
     - name: Install PHP
       uses: shivammathur/setup-php@v2
       with:

--- a/.github/actions/poetry-install/action.yml
+++ b/.github/actions/poetry-install/action.yml
@@ -8,6 +8,11 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Log deprecation warning
+      shell: bash
+      run: |
+        echo "::warning title=Action deprecated::Please switch to the standlone version of this action: https://github.com/minvws/action-python-poetry-install"
+
     - name: Update PATH
       shell: bash
       run: echo "$HOME/.local/bin" >> $GITHUB_PATH

--- a/.github/actions/python-venv-package/action.yml
+++ b/.github/actions/python-venv-package/action.yml
@@ -23,6 +23,11 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Log deprecation warning
+      shell: bash
+      run: |
+        echo "::warning title=Action deprecated::Please switch to the standlone version of this action: https://github.com/minvws/action-python-venv-package"
+
     - name: Set release version
       shell: bash
       run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV

--- a/.github/actions/sonarcloud/action.yml
+++ b/.github/actions/sonarcloud/action.yml
@@ -12,6 +12,10 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Log deprecation warning
+      shell: bash
+      run: |
+        echo "::warning title=Action deprecated::Please switch to the standlone version of this action: https://github.com/minvws/action-sonarqube"
     - name: 'Run SonarCloud scanner'
       if: ${{contains(github.ref, '/pull/')}}
       uses: SonarSource/sonarqube-scan-action@v5

--- a/.github/actions/src-package/action.yml
+++ b/.github/actions/src-package/action.yml
@@ -25,6 +25,11 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Log deprecation warning
+      shell: bash
+      run: |
+        echo "::warning title=Action deprecated::Please switch to the standlone version of this action: https://github.com/minvws/action-generic-build-package"
+
     - name: Checkout code
       if: inputs.checkout_repository == 'true'
       uses: actions/checkout@v5

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Generic Pipelines
 
+> [!WARNING]  
+> This repository is deprecated. The actions and workflows have been moved
+> to standalone repositories. Please see [actions.md](actions.md) and
+> [pipelines.md](pipelines.md) for references to the new repositories.
+
 This repository contains a collection of generic GitHub Actions pipelines that can be used in any project.
 The pipelines are designed to be as generic as possible, so they can be easily reused in any project.
 

--- a/actions.md
+++ b/actions.md
@@ -1,5 +1,10 @@
 # Actions
 
+> [!WARNING]
+> The actions in this repository have been moved to standalone repositories. You
+> can find links to the new repositories above the instructions for each action
+> below.
+
 Here you can find the available actions. Each section will provide a description about the action and how you can use it in your project.
 
 Available actions:
@@ -15,6 +20,9 @@ Available actions:
   - [GFModules Trigger CI](#gfmodules-trigger-ci)
 
 ## Python - Poetry install
+
+> [!WARNING]
+> Please use [minvws/action-python-poetry-install](https://github.com/minvws/action-python-poetry-install) instead.
 
 This pipeline is designed to install the dependencies of a Python project that uses Poetry. It will install the dependencies and cache them for future runs.
 
@@ -62,6 +70,9 @@ The action has inputs. The inputs are:
 - python_version: Semver version of the Python version you want to use. For example `3.11` or `3.9`.
 
 ## Python - venv package
+
+> [!WARNING]
+> Please use [minvws/action-python-venv-package](https://github.com/minvws/action-python-venv-package) instead.
 
 This pipeline is designed to export a venv package for the specified Python version with the installed requirements. When [Poetry](https://python-poetry.org/) is used, the requirements will be exported and the requirements will be installed in the venv.
 
@@ -152,6 +163,9 @@ The name of the artifact will be `<package_file_name>_venv_<tag_version>_python<
 The uploaded artifact will have a limited lifetime depending on what is currently configured.
 
 ## Source package
+
+> [!WARNING]
+> Please use [minvws/action-generic-build-package](https://github.com/minvws/action-generic-build-package) instead.
 
 This pipeline is designed to export a source package for an application.
 
@@ -249,6 +263,9 @@ The uploaded artifact will have a limited lifetime depending on what is currentl
 
 ## PHP - Composer install
 
+> [!WARNING]
+> Please use [minvws/action-php-composer-install](https://github.com/minvws/action-php-composer-install) instead.
+
 This pipeline is designed to install the dependencies of a PHP project that uses Composer. It will install the dependencies and cache them for future runs.
 
 ### Usage
@@ -296,6 +313,9 @@ The action has inputs. The inputs are:
 - php_version: Semver version of the PHP version you want to use. For example `8.2` or `8.3`.
 
 ## GFModules Trigger CI
+
+> [!WARNING]
+> Please use [minvws/gfmodules-action-trigger-ci](https://github.com/minvws/gfmodules-action-trigger-ci) instead.
 
 This pipeline is designed to trigger a TI (test integration) workflow for a GFModules project. It will trigger the workflow and pass the necessary parameters.
 

--- a/pipelines.md
+++ b/pipelines.md
@@ -1,5 +1,10 @@
 # Pipelines
 
+> [!WARNING]  
+> The workflows in this repository have been moved to standalone repositories.
+> You can find links to the new repositories above the instructions for each
+> workflow below.
+
 Here you can find the available pipelines. Each section will provide a description about the pipeline and how you can use it in your project.
 
 Available pipelines:
@@ -7,6 +12,9 @@ Available pipelines:
 - [Repo sync](#repo-sync)
 
 ## Repo sync
+
+> [!WARNING]
+> Please use [minvws/workflow-repo-sync](https://github.com/minvws/workflow-repo-sync) instead.
 
 This pipeline synchronizes:
 


### PR DESCRIPTION
Add some deprecation warnings and references to the new standalone actions to the docs and logged as a `::warning` while running the action.

I've skipped the `::warning` for gfmodules-action-trigger-ci as that runs fully in JS (adding it there would warrant testing and I don't think it's important enough).